### PR TITLE
Fix "Check / Secrets" job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,6 +54,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          fetch-depth: 0
       - name: Scan for secrets
         uses: gitleaks/gitleaks-action@1f2d10fb689bc07a5f56f48d6db61f5bbbe772fa # v2.3.2
         env:


### PR DESCRIPTION
## Summary

Fetch entire history for the "Check / Secrets" job to ensure [gitleaks](https://github.com/gitleaks/gitleaks-action) can work properly.