### PR TITLE
Implement checksum verification for downloaded archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to _asdf-yamllint_ will be documented in this file.
 
 ## Changes
 
+- (2023-01-15) Add checksum verification.
 - (2023-01-15) Improve prerequisite checks.
 - (2023-01-15) Fix `download` and `install` script errors on OSX.
 - (2023-01-14) Initial release.

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ test-download:
 else
 test-download: | $(TMP_DIR) ## Test run the bin/download script
 	@rm -rf \
+		"${TMP_DIR}/download/checksum.txt" \
 		"${TMP_DIR}/download/yamllint-$(version).tar.gz" \
 		"${TMP_DIR}/download/yamllint-$(version)"
 	@( \
@@ -55,6 +56,7 @@ test-install:
 else
 test-install: | $(TMP_DIR) ## Test run the bin/install script
 	@rm -rf \
+		"${TMP_DIR}/install/checksum.txt" \
 		"${TMP_DIR}/install/yamllint-$(version).tar.gz" \
 		"${TMP_DIR}/install/bin/yamllint" \
 		"${TMP_DIR}/install/yamllint-$(version)"

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ test-download:
 else
 test-download: | $(TMP_DIR) ## Test run the bin/download script
 	@rm -rf \
+		"${TMP_DIR}/download/yamllint-$(version).tar.gz" \
 		"${TMP_DIR}/download/yamllint-$(version)"
 	@( \
 		ASDF_DOWNLOAD_PATH="${TMP_DIR}/download" \
@@ -54,6 +55,7 @@ test-install:
 else
 test-install: | $(TMP_DIR) ## Test run the bin/install script
 	@rm -rf \
+		"${TMP_DIR}/install/yamllint-$(version).tar.gz" \
 		"${TMP_DIR}/install/bin/yamllint" \
 		"${TMP_DIR}/install/yamllint-$(version)"
 	@( \

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -81,7 +81,7 @@ download_version() {
 		--file "${tar_file}" \
 		"yamllint-${version}"
 
-	rm --force "${checksum_file}" "${tar_file}"
+	rm -f "${checksum_file}" "${tar_file}"
 }
 
 install_version() {


### PR DESCRIPTION
Closes #3

## Summary

Implement checksum verification in the `download_version` routine in order to verify the archives' downloaded by `bin/download` and `bin/install` have digests that match what's advertised by PyPI.