### PR TITLE
Add and use `shfmt`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,16 @@ on:
 permissions: read-all
 
 jobs:
+  format:
+    name: Format
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: Install tooling
+        uses: asdf-vm/actions/install@707e84f3ee349548310aeabdad0dd3bfcb9b69fa # v1.1.0
+      - name: Check formatting
+        run: make format-check
   lint:
     name: Lint
     runs-on: ubuntu-22.04

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,6 +19,7 @@ jobs:
         tool:
           - actionlint
           - shellcheck
+          - shfmt
     steps:
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,3 +2,4 @@
 
 actionlint 1.6.22
 shellcheck 0.9.0
+shfmt 3.6.0

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,20 @@ clean: ## Clean the repository
 	@git clean -fx \
 		$(TMP_DIR)
 
+format:
+	@shfmt --simplify --write \
+		./$(BIN_DIR)/download \
+		./$(BIN_DIR)/install \
+		./$(BIN_DIR)/list-all \
+		./lib/common.sh
+
+format-check:
+	@shfmt --diff \
+		./$(BIN_DIR)/download \
+		./$(BIN_DIR)/install \
+		./$(BIN_DIR)/list-all \
+		./lib/common.sh
+
 help: ## Show this help message
 	@printf "Usage: make <command>\n\n"
 	@printf "Commands:\n"
@@ -73,7 +87,7 @@ test-installation: ## Test that the bin/install script worked
 test-list-all: ## Test run the bin/list-all script
 	@./$(BIN_DIR)/list-all
 
-.PHONY: clean default help lint lint-ci lint-sh release test-download test-install test-installation test-list-all
+.PHONY: clean default format format-check help lint lint-ci lint-sh release test-download test-install test-installation test-list-all
 
 $(TMP_DIR):
 	@mkdir $(TMP_DIR)

--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,14 @@ clean: ## Clean the repository
 	@git clean -fx \
 		$(TMP_DIR)
 
-format:
+format: ## Format the source code
 	@shfmt --simplify --write \
 		./$(BIN_DIR)/download \
 		./$(BIN_DIR)/install \
 		./$(BIN_DIR)/list-all \
 		./lib/common.sh
 
-format-check:
+format-check: ## Check the source code formatting
 	@shfmt --diff \
 		./$(BIN_DIR)/download \
 		./$(BIN_DIR)/install \

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -18,7 +18,7 @@ _check_prerequisite() {
 
 # Based on https://github.com/rbenv/ruby-build/blob/697bcff/bin/ruby-build#L1371-L1374
 _sort_versions() {
-	sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
+	sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
 		LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
@@ -73,7 +73,7 @@ download_version() {
 	if ! command -v shasum &>/dev/null; then
 		shasum_command='sha256sum'
 	fi
-	echo "${tar_checksum}  ${tar_file}" > "${checksum_file}"
+	echo "${tar_checksum}  ${tar_file}" >"${checksum_file}"
 	${shasum_command} --quiet --check "${checksum_file}"
 
 	tar --extract --gzip \
@@ -109,7 +109,7 @@ install_version() {
 	fi
 
 	(
-		cd "${install_path}/yamllint-${version}";
+		cd "${install_path}/yamllint-${version}"
 		${python_command} -m pip install --quiet --requirement yamllint.egg-info/requires.txt
 	)
 	{
@@ -117,6 +117,6 @@ install_version() {
 		echo ''
 		echo "PYTHONPATH=\"\${PYTHONPATH}:${install_path}/yamllint-${version}\" \\"
 		echo "${python_command} '${install_path}/yamllint-${version}/yamllint/__main__.py' \"\$@\""
-	} >> "${bin_path}"
+	} >>"${bin_path}"
 	chmod +x "${bin_path}"
 }


### PR DESCRIPTION
## Summary

Add [shfmt] as a tool and use it for formatting shell scripts. A `make format` target is provided to easily format the code base as expected. `make format-check` can be used to check formatting, this is done continuously with the "Check / Formatting" continuous integration check.

[shfmt]: https://github.com/mvdan/sh