### PR TITLE
Remove prerequisites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to _asdf-yamllint_ will be documented in this file.
 
 ## Changes
 
+- (2023-01-21) Remove prerequisite checks.
 - (2023-01-19) Add support for using `python`.
 - (2023-01-15) Add checksum verification.
 - (2023-01-15) Improve prerequisite checks.

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -5,16 +5,6 @@ set -eo pipefail
 base_url="https://pypi.org/pypi/yamllint"
 
 exit_code_missing_env_var=1
-exit_code_missing_cmd=2
-
-_check_prerequisite() {
-	local -r name="$1"
-
-	if [ -z "$(command -v "${name}")" ]; then
-		echo "'${name} 'is required for this command"
-		exit "${exit_code_missing_cmd}"
-	fi
-}
 
 _get_python_command() {
 	# Both `python3` and `python` are names commonly used for the Python 3 binary.
@@ -70,24 +60,12 @@ check_env_var() {
 }
 
 list_versions() {
-	_check_prerequisite 'curl'
-	_check_prerequisite 'jq'
-	_check_prerequisite 'sed'
-	_check_prerequisite 'sort'
-	_check_prerequisite 'awk'
-
 	curl --silent "${base_url}/json" |
 		jq --raw-output '.releases | keys[]' |
 		_sort_versions
 }
 
 download_version() {
-	_check_prerequisite 'curl'
-	_check_prerequisite 'dirname'
-	_check_prerequisite 'jq'
-	_check_prerequisite 'rm'
-	_check_prerequisite 'tar'
-
 	local -r version="$1"
 	local -r download_path="$2"
 
@@ -117,9 +95,6 @@ download_version() {
 }
 
 install_version() {
-	_check_prerequisite 'mkdir'
-	_check_prerequisite 'cp'
-
 	local -r version="$1"
 	local -r install_path="$2"
 	local -r download_path="$3"


### PR DESCRIPTION
Relates to #7
Supersedes #17

## Summary

Remove all prerequisites checks. They're of limited value (scripts will fail due to them missing anyway), hard to maintain (manual review is required to see if prerequisites are still up-to-date, this can be especially problematic when a prerequisite is no longer necessary), and can't cover more complex cases such as the use of `python3` *or* `python`.