### PR TITLE
Update checksum validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to _asdf-yamllint_ will be documented in this file.
 
 ## Changes
 
+- (2023-02-20) Improve checksum verification system compatibility.
 - (2023-01-21) Remove prerequisite checks.
 - (2023-01-19) Add support for using `python`.
 - (2023-01-15) Add checksum verification.

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -38,13 +38,13 @@ _validate_checksum() {
 	# Different systems have different programs for computing SHA checksums. To
 	# broaden support, multiple programs are considered. We use whichever one is
 	# available on the current system.
-	local shasum_command='shasum --algorithm 256'
+	local shasum_command='shasum -q -a 256'
 	if ! command -v shasum &>/dev/null; then
-		shasum_command='sha256sum'
+		shasum_command='sha256sum -s'
 	fi
 
 	echo "${expected_checksum}  ${file}" >"${checksum_file}"
-	${shasum_command} --quiet --check "${checksum_file}"
+	${shasum_command} -c "${checksum_file}"
 
 	rm -f "${checksum_file}"
 }


### PR DESCRIPTION
Caused by #22

## Summary

Update the checksum validation implementation to:

1. Use shorthand flags. Some implementations of `shasum` and `sha256sum` only support shorthand flags.
2. use `-q` (quiet) for `shasum` and `-s` (silent) for `sha256sum`. This seems to be the most commonly supported.