### PR TITLE
Find download URL dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to _asdf-yamllint_ will be documented in this file.
 
 ## Changes
 
+- (2023-03-24) Fix `null` error when downloading certain yamllint versions.
 - (2023-02-20) Improve checksum verification system compatibility.
 - (2023-01-21) Remove prerequisite checks.
 - (2023-01-19) Add support for using `python`.

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -70,7 +70,7 @@ download_version() {
 	local -r download_path="$2"
 
 	local -r version_json="$(curl --silent "${base_url}/${version}/json")"
-	local -r download_json="$(echo "${version_json}" | jq -r '.urls[1]')"
+	local -r download_json="$(echo "${version_json}" | jq -r '.urls[] | select(.packagetype == "sdist")')"
 	local -r download_url="$(echo "${download_json}" | jq -r '.url')"
 	local -r tar_checksum="$(echo "${download_json}" | jq -r '.digests.sha256')"
 


### PR DESCRIPTION
Closes #29

## Summary

Update the logic that determines the download URL for the yamllint tarball to search for the `urls` entry with the correct(?) package type instead of just using the second entry.

This is necessary as various (most?) yamllint releases also include a URL for a `.whl` file. However, per #29, v1.30.0 does not.