### PR TITLE
Initial support for new(?) `requires.txt` format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to _asdf-yamllint_ will be documented in this file.
 
 ## Changes
 
+- (2023-04-22) Fix installation error due to `[dev]` directive.
 - (2023-03-24) Fix `null` error when downloading certain yamllint versions.
 - (2023-02-20) Improve checksum verification system compatibility.
 - (2023-01-21) Remove prerequisite checks.

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,12 @@ else
 endif
 
 test-installation: ## Test the installation
+	@echo 'INSTALLED VERSION:'
+	@echo '------------------'
+	@$(TMP_DIR)/install/bin/yamllint --version
+	@echo
+	@echo 'HELP TEXT:'
+	@echo '----------'
 	@$(TMP_DIR)/install/bin/yamllint --help
 
 test-list-all: ## Test run the list-all script

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -112,6 +112,7 @@ install_version() {
 
 	(
 		cd "${install_path}/yamllint-${version}"
+		sed -i -e '/^\[/d' yamllint.egg-info/requires.txt
 		${python_command} \
 			-m pip install \
 			--quiet \


### PR DESCRIPTION
Closes #38

## Summary

Update the installation script to avoid an error first observed with yamllint v1.31.0 due to a `[dev]` directive in the `requires.txt` file.

This is probably not the best/correct solution, but it works and allows for installing the latest version of yamllint. Suggestions for better solutions are welcome.