### PR TITLE
Document prerequisites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to _asdf-yamllint_ will be documented in this file.
 
 ## Changes
 
+- (2023-04-22) Document prerequisites.
 - (2023-04-22) Fix installation error due to `[dev]` directive.
 - (2023-03-24) Fix `null` error when downloading certain yamllint versions.
 - (2023-02-20) Improve checksum verification system compatibility.

--- a/README.md
+++ b/README.md
@@ -20,5 +20,14 @@ asdf plugin add yamllint https://github.com/ericcornelissen/asdf-yamllint
 asdf install yamllint 1.29.0
 ```
 
+## Prerequisites
+
+To be able to use this [asdf] plugin you need at least the following:
+
+- Either `python3` or `python`
+- Either `shasum` or `sha256sum`
+- Unix utilities: `awk`, `bash`, `command`, `cp`, `curl`, `dirname`, `jq`,
+  `mkdir`, `rm`, `sed`, `sort`, and `tar`
+
 [asdf]: https://asdf-vm.com
 [yamllint]: https://github.com/adrienverge/yamllint


### PR DESCRIPTION
Relates to #7, #17, #18

## Summary

Add a new section to the README with the prerequisite tooling to be able to use this asdf plugin. This was inspired by the [asdf-syft] documentation's "Dependencies" section.

[asdf-syft]: https://github.com/davidgp1701/asdf-syft