### PR TITLE
Add branch check to `make release` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,10 @@ lint-sh: $(ASDF) ## Lint .sh files
 	@shellcheck $(ALL_SCRIPTS)
 
 release: ## Release a new version
-ifeq "$v" ""
+ifneq "$(shell git branch --show-current)" "main"
+	@echo 'refusing to release, not on main branch'
+	@echo 'first run: "git switch main"'
+else ifeq "$v" ""
 	@echo 'usage: "make release v=1.0.1"'
 else
 	@git tag "v$v"


### PR DESCRIPTION
## Summary

Include a check for the current branch in the `make release` target in order to avoid releasing from any branch but `main`. For this project, all releases must be on the `main` branch (pre-releases are not used).

This follows me accidentally releasing [v1.0.7](https://github.com/ericcornelissen/asdf-yamllint/releases/tag/v1.0.7) from #40's branch today (_already fixed_).