### PR TITLE
Update the security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,41 +1,67 @@
 # Security Policy
 
+The maintainers of the _asdf-yamllint_ take security issues seriously. We
+appreciate your efforts to responsibly disclose your findings. Due to the
+non-funded and open-source nature of the project, we take a best-efforts
+approach when it comes to engaging with security reports.
+
 ## Supported Versions
 
-The table below shows which versions of _asdf-yamllint_ are currently supported
-with security updates.
+The table below shows which versions of the project are currently supported with
+security updates.
 
 | Version | End-of-life |
 | ------: | :---------- |
 |   1.x.x | -           |
 
+_This table only includes information on versions `<2.0.0`._
+
 ## Reporting a Vulnerability
 
-The maintainers of this project take security bugs very seriously. We appreciate
-your efforts to responsibly disclose your findings. Due to the non-funded and
-open-source nature of this project, we take a best-efforts approach when it
-comes to engaging with (security) reports.
+To report a security issue in the latest version of a supported version range,
+either (in order of preference):
 
-To report a security issue in a supported version of the project, send an email
-to [security@ericcornelissen.dev] and include the terms "SECURITY" and
-"asdf-yamllint" in the subject line. Please do not open a regular issue or Pull
-Request in the public repository.
+- [Report it through GitHub][new github advisory], or
+- Send an email to [security@ericcornelissen.dev] with the terms "SECURITY" and
+  "asdf-yamllint" in the subject line.
 
-If you found a security bug in an unsupported version of the project, please
-report this publicly. For example, as a regular issue in the public repository.
+Please do not open a regular issue or Pull Request in the public repository.
+
+To report a security issue in an unsupported version of the project, or if the
+latest version of a supported version range isn't affected, please report it
+publicly. For example, as a regular issue in the public repository. If in doubt,
+report the issue privately.
+
+[new github advisory]: https://github.com/ericcornelissen/asdf-yamllint/security/advisories/new
+[security@ericcornelissen.dev]: mailto:security@ericcornelissen.dev?subject=SECURITY%20%28asdf-yamllint%29
+
+### What to Include in a Report
+
+Try to include as many of the following items as possible in a security report:
+
+- An explanation of the issue
+- A proof of concept exploit
+- A suggested severity
+- Relevant [CWE] identifiers
+- The latest affected version
+- The earliest affected version
+- A suggested patch
+
+[cwe]: https://cwe.mitre.org/
 
 ## Advisories
 
-> **Note** Ordered most to least recent.
+> **Note**: Advisories will be created only for vulnerabilities present in
+> released versions of the project.
 
 | ID               | Date       | Affected versions | Patched versions |
 | :--------------- | :--------- | :---------------- | :--------------- |
 | -                | -          | -                 | -                |
+
+_This table is ordered most to least recent._
 
 ## Acknowledgments
 
 We would like to publicly thank the following reporters:
 
 - _None yet_
-
-[security@ericcornelissen.dev]: mailto:security@ericcornelissen.dev?subject=SECURITY%20%28asdf-yamllint%29

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 # Security Policy
 
-The maintainers of the _asdf-yamllint_ take security issues seriously. We
-appreciate your efforts to responsibly disclose your findings. Due to the
+The maintainers of the _asdf-yamllint_ project take security issues seriously.
+We appreciate your efforts to responsibly disclose your findings. Due to the
 non-funded and open-source nature of the project, we take a best-efforts
 approach when it comes to engaging with security reports.
 


### PR DESCRIPTION
## Summary

Update the security policy content by:
- Adding a proper introduction, similar to the Contributing Guidelines.
- Adding the option to report publicly if the latest available version of supported ranges aren't affected.
- Adding suggestions for what to include in a security report.
- Adding a note that only vulnerabilities present in released software will get an advisory in order to set expectations.
- Adding the (preferred) option of reporting issues through GitHub.
- Generally rewriting things for clarity and brevity.