### PR TITLE
Pre-install tooling in development image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,16 @@ RUN apk add --no-cache \
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+WORKDIR /setup
+COPY .tool-versions .
+
 RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.11.1 \
 	&& echo '. "$HOME/.asdf/asdf.sh"' > ~/.bashrc \
 	&& . "$HOME/.asdf/asdf.sh" \
 	&& asdf plugin add actionlint \
 	&& asdf plugin add hadolint \
 	&& asdf plugin add shellcheck \
-	&& asdf plugin add shfmt
+	&& asdf plugin add shfmt \
+	&& asdf install
 
 ENTRYPOINT ["/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ $(TMP_DIR):
 $(ASDF): .tool-versions | $(TMP_DIR)
 	@asdf install
 	@touch $(ASDF)
-$(DEV_IMG): Dockerfile | $(TMP_DIR)
+$(DEV_IMG): .tool-versions Dockerfile | $(TMP_DIR)
 	@docker build \
 		--tag asdf-yamllint-dev-img \
 		.


### PR DESCRIPTION
Relates to #22

## Summary

Update the `Dockerfile` development image to install development tooling upon image creation by copying the `.tool-versions` file into the image and running `asdf install`. This streamlines development using this image by avoiding the need to re-install the tooling every time the image is used to create a ephemeral development environment.