### PR TITLE
Add help scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to _asdf-yamllint_ will be documented in this file.
 
 ## Changes
 
+- (2023-07-22) Add support for `asdf help yamllint`.
 - (2023-04-22) Document prerequisites.
 - (2023-04-22) Fix installation error due to `[dev]` directive.
 - (2023-03-24) Fix `null` error when downloading certain yamllint versions.

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ else
 	@git push origin "v$v"
 endif
 
-.PHONY: test-download test-install test-installation test-list-all
+.PHONY: test-download test-help test-install test-installation test-list-all
 test-download: | $(TMP_DIR) ## Test run the download script
 ifeq "$(version)" ""
 	@echo 'usage: "make test-download version=1.29.0"'
@@ -80,6 +80,16 @@ else
 		./$(BIN_DIR)/download \
 	)
 endif
+
+test-help: ## Test the help scripts
+	@echo "OVERVIEW"
+	@./$(BIN_DIR)/help.overview
+	@echo
+	@echo "DEPENDENCIES"
+	@./$(BIN_DIR)/help.deps
+	@echo
+	@echo "LINKS"
+	@./$(BIN_DIR)/help.links
 
 test-install: | $(TMP_DIR) ## Test run the install script
 ifeq "$(version)" ""

--- a/bin/help.deps
+++ b/bin/help.deps
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+echo "awk
+bash
+command
+cp
+curl
+dirname
+jq
+mkdir
+python / python3
+rm
+sed
+shasum / sha256sum
+sort
+tar"

--- a/bin/help.links
+++ b/bin/help.links
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "Git repository : https://github.com/adrienverge/yamllint
+Documentation  : https://yamllint.readthedocs.io"

--- a/bin/help.overview
+++ b/bin/help.overview
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo "This plugin provides access to yamllint - a linter for YAML files.
+
+yamllint is 'GNU General Public License v3.0' licensed software."


### PR DESCRIPTION
Closes #6 

## Summary

Create the help scripts for the plugin as prescribed in the [`asdf` docs for plugins](https://asdf-vm.com/plugins/create.html). All help scripts have been created except for `bin/help.config`, which doesn't apply to this plugin (no configuration is required, as far as I know).
