### PR TITLE
Add SPDX license identifiers to source code

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
 
 set -eo pipefail
 

--- a/bin/help.deps
+++ b/bin/help.deps
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
 
 echo "awk
 bash

--- a/bin/help.links
+++ b/bin/help.links
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
 
 echo "Git repository : https://github.com/adrienverge/yamllint
 Documentation  : https://yamllint.readthedocs.io"

--- a/bin/help.overview
+++ b/bin/help.overview
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
 
 echo "This plugin provides access to yamllint - a linter for YAML files.
 

--- a/bin/install
+++ b/bin/install
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
 
 set -eo pipefail
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
 
 set -eo pipefail
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
 
 set -eo pipefail
 


### PR DESCRIPTION
## Summary

Add license identifiers following the [SPDX license id format](https://spdx.dev/ids/) to all source code files.
