### PR TITLE
Add SPDX license identifiers to documentation files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Changelog
 
 All notable changes to _asdf-yamllint_ will be documented in this file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Contributing Guidelines
 
 The maintainers of _asdf-yamllint_ welcome contributions and corrections. This

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
 # `asdf-yamllint`
 
 An [asdf] plugin for [yamllint].

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Security Policy
 
 The maintainers of the _asdf-yamllint_ project take security issues seriously.


### PR DESCRIPTION
Relates to #61

## Summary

Add license identifiers following the [SPDX license id format](https://spdx.dev/ids/) to all (internal and external facing) documentation files.