### PR TITLE
Replace `Dockerfile` with `Containerfile`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,5 +18,5 @@ indent_size=unset
 indent_style=space
 indent_size=2
 
-[{Dockerfile,Makefile}]
+[{Containerfile,Makefile}]
 indent_style=tab

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,14 +2,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: docker
-    directory: /
-    open-pull-requests-limit: 1
-    schedule:
-      interval: daily
-      time: "05:00"
-    labels:
-      - dependencies
   - package-ecosystem: github-actions
     directory: /
     open-pull-requests-limit: 1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,9 +37,9 @@ jobs:
       - name: Lint CI workflows
         if: ${{ failure() || success() }}
         run: make lint-ci
-      - name: Lint Dockerfile
+      - name: Lint Containerfile
         if: ${{ failure() || success() }}
-        run: make lint-docker
+        run: make lint-container
       - name: Lint shell scripts
         if: ${{ failure() || success() }}
         run: make lint-sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ To be able to contribute you need the following tooling:
 - (Recommended) a code editor with [EditorConfig] support;
 - (Recommended) [Python] v3;
 - (Optional) [actionlint] (see `.tool-versions` for preferred version);
-- (Optional) [Docker] (development environment available)
+- (Optional) [Docker] or [Podman] (development environment available)
 - (Optional) [hadolint] (see `.tool-versions` for preferred version);
 - (Optional) [ShellCheck] (see `.tool-versions` for preferred version);
 - (Optional) [shfmt] (see `.tool-versions` for preferred version);
@@ -40,6 +40,7 @@ To be able to contribute you need the following tooling:
 [git]: https://git-scm.com/
 [hadolint]: https://github.com/hadolint/hadolint
 [make]: https://www.gnu.org/software/make/
+[podman]: https://podman.io/
 [python]: https://www.python.org/
 [security policy]: ./SECURITY.md
 [shellcheck]: https://github.com/koalaman/shellcheck

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,6 @@
-# Check out Docker at: https://www.docker.com/
-# NOTE: this image is intended for development purposes only.
+# Defines a development environment container image. Can be used with:
+# - Docker: https://www.docker.com/
+# - Podman: https://podman.io/
 
 FROM alpine:3.18.4
 

--- a/Containerfile
+++ b/Containerfile
@@ -10,14 +10,13 @@ RUN apk add --no-cache \
 	# project prerequisites
 	jq make python3 py3-pip
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
 WORKDIR /setup
 COPY .tool-versions .
 
-RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.11.1 \
-	&& echo '. "$HOME/.asdf/asdf.sh"' > ~/.bashrc \
-	&& . "$HOME/.asdf/asdf.sh" \
+ENV ASDF_DIR="/.asdf"
+RUN git clone https://github.com/asdf-vm/asdf.git /.asdf --branch v0.11.1 \
+	&& echo '. "/.asdf/asdf.sh"' > ~/.bashrc \
+	&& . "/.asdf/asdf.sh" \
 	&& asdf plugin add actionlint \
 	&& asdf plugin add hadolint \
 	&& asdf plugin add shellcheck \

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+CONTAINER_ENGINE?=docker
+
 TMP_DIR:=.tmp
 BIN_DIR:=bin
 
@@ -15,8 +17,8 @@ clean: ## Clean the repository
 		$(TMP_DIR)
 
 .PHONY: dev-env dev-img
-dev-env: dev-img ## Run an ephemeral dev env with Docker
-	@docker run \
+dev-env: dev-img ## Run an ephemeral development environment container
+	@$(CONTAINER_ENGINE) run \
 		-it \
 		--rm \
 		--workdir "/asdf-yamllint" \
@@ -24,7 +26,7 @@ dev-env: dev-img ## Run an ephemeral dev env with Docker
 		--name "asdf-yamllint-dev" \
 		asdf-yamllint-dev-img
 
-dev-img: $(DEV_IMG) ## Build a dev env image with Docker
+dev-img: $(DEV_IMG) ## Build a development environment image
 
 .PHONY: format format-check
 format: $(ASDF) ## Format the source code
@@ -41,14 +43,14 @@ help: ## Show this help message
 		printf "  \033[36m%-30s\033[0m %s\n", $$1, $$NF \
 	}' $(MAKEFILE_LIST)
 
-.PHONY: lint lint-ci lint-docker lint-sh
-lint: lint-ci lint-docker lint-sh ## Run lint-*
+.PHONY: lint lint-ci lint-container lint-sh
+lint: lint-ci lint-container lint-sh ## Run lint-*
 
 lint-ci: $(ASDF) ## Lint CI workflow files
 	@actionlint
 
-lint-docker: $(ASDF) ## Lint the Dockerfile
-	@hadolint Dockerfile
+lint-container: $(ASDF) ## Lint the Containerfile
+	@hadolint Containerfile
 
 lint-sh: $(ASDF) ## Lint .sh files
 	@shellcheck $(ALL_SCRIPTS)
@@ -127,8 +129,9 @@ $(TMP_DIR):
 $(ASDF): .tool-versions | $(TMP_DIR)
 	@asdf install
 	@touch $(ASDF)
-$(DEV_IMG): .tool-versions Dockerfile | $(TMP_DIR)
-	@docker build \
+$(DEV_IMG): .tool-versions Containerfile | $(TMP_DIR)
+	@$(CONTAINER_ENGINE) build \
 		--tag asdf-yamllint-dev-img \
+		--file Containerfile \
 		.
 	@touch $(DEV_IMG)


### PR DESCRIPTION
Relates to #22

## Summary

Move to a `Containerfile` based ephemeral development environment container image in order to be vendor agnostic. Ideally, nothing much changes except that it will become easier to use a different container engine when working on this project.