### PR TITLE
Update `asdf` to the latest available version in the dev env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR /setup
 COPY .tool-versions .
 
-RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.11.1 \
+RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.13.1 \
 	&& echo '. "$HOME/.asdf/asdf.sh"' > ~/.bashrc \
 	&& . "$HOME/.asdf/asdf.sh" \
 	&& asdf plugin add actionlint \


### PR DESCRIPTION
Relates to #22

## Summary

Update the version of `asdf` used in the development environment container to the latest available version, [v.0.13.1](https://github.com/asdf-vm/asdf/blob/fce6c534daf6c0b2eed7dc633b18f7b87f665d2f/CHANGELOG.md).