### PR TITLE
Add SPDX license identifiers to (remaining) non-configuration files

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 # Defines a development environment container image. Can be used with:
 # - Docker: https://www.docker.com/
 # - Podman: https://podman.io/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 CONTAINER_ENGINE?=docker
 
 TMP_DIR:=.tmp


### PR DESCRIPTION
Relates to #61, #82

## Summary

Add license identifiers following the [SPDX license id format](https://spdx.dev/ids/) to all remaining non-configuration files.