### PR TITLE
Configure default assignee for bot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,7 @@ updates:
     schedule:
       interval: daily
       time: "05:00"
+    assignees:
+      - ericcornelissen
     labels:
       - dependencies

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Update tooling
         uses: ericcornelissen/tool-versions-update-action/pr@80dab8d99cefefdcfcc6ad4adbb6bc7a07c39e7f # v0.3.7
         with:
+          assignees: ericcornelissen
           labels: dependencies
           max: 1
           token: ${{ steps.automation-token.outputs.token }}


### PR DESCRIPTION
## Summary

Configure Dependabot and [`ericcornelissen/tool-versions-update-action`](https://github.com/ericcornelissen/tool-versions-update-action) to automatically set the default assignee for Pull Requests they generating. This is based on historical precedence [for Dependabot](https://github.com/ericcornelissen/asdf-yamllint/pulls?q=is%3Apr+author%3Aapp%2Fdependabot) and [for other automated PRs](https://github.com/ericcornelissen/asdf-yamllint/pulls?q=is%3Apr+author%3Aapp%2Fec-automation-bot).

The configuration changes are based on the [Dependabot docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#assignees) and [`ericcornelissen/tool-versions-update-action` docs](https://github.com/ericcornelissen/tool-versions-update-action/tree/v0.3.7/pr#usage).