### PR TITLE
License supporting code more permissively

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: MIT-0
 
 # Check out Docker at: https://www.docker.com/
 # Check out Podman at: https://podman.io/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: MIT-0
 
 CONTAINER_ENGINE?=docker
 


### PR DESCRIPTION
Relates to #86

## Summary

Make re-use of supporting code (i.e. code not (used when) distributed) easier by removing the attribution requirement.