### PR TITLE
Try `macos-14` as MacOS runners in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -70,7 +70,7 @@ jobs:
       matrix:
         include:
           - name: MacOS
-            os: macos-13
+            os: macos-14
           - name: Ubuntu
             os: ubuntu-22.04
     steps:


### PR DESCRIPTION
Relates to #2, #45

## Summary

Update CI jobs that run on MacOS to use `macos-14` instead of `macos-13`. This was released today and is still in beta, hence this is just for trying it out and seeing if it works.

See also
- <https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/>
- <https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/>