### PR TITLE
Upgrade development environment base image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -3,7 +3,7 @@
 # Check out Docker at: https://www.docker.com/
 # Check out Podman at: https://podman.io/
 
-FROM docker.io/alpine:3.18.4
+FROM docker.io/alpine:3.19.1
 
 RUN apk add --no-cache \
 	# asdf prerequisites


### PR DESCRIPTION
Relates to #76, #112

## Summary

Upgrade the development environment's base image from 3.18.4 to 3.19.1 - the latest available version. This new environment requires `venv` to work, hence this depends on #112.