### PR TITLE
running yamllint with asdf should preserve the return code of yamllint

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -136,7 +136,9 @@ install_version() {
 		echo "source '${venv_path}/bin/activate'"
 		echo "PYTHONPATH=\"\${PYTHONPATH}:${install_path}/yamllint-${version}\" \\"
 		echo "${python_command} '${install_path}/yamllint-${version}/yamllint/__main__.py' \"\$@\""
+		echo "ret_val=\$?"
 		echo "deactivate"
+		echo "exit \"\${ret_val}\""
 	} >>"${bin_path}"
 	chmod +x "${bin_path}"
 }


### PR DESCRIPTION
The last command run by asdf after running yamllint is `deactivate`. This will mask the return value of yamllint.

By storing the return value as an intermediate step we can exit using that return value and the return value of yamllint will be preserved.

Fixes #118 