### PR TITLE
Upgrade the Ubuntu-based runner used in CI to 24.04

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,7 @@ permissions: read-all
 jobs:
   dev-env:
     name: Dev env
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -18,7 +18,7 @@ jobs:
         run: make dev-img
   format:
     name: Format
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -28,7 +28,7 @@ jobs:
         run: make format-check
   lint:
     name: Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -45,7 +45,7 @@ jobs:
         run: make lint-sh
   test:
     name: Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -72,7 +72,7 @@ jobs:
           - name: MacOS
             os: macos-14
           - name: Ubuntu
-            os: ubuntu-22.04
+            os: ubuntu-24.04
     steps:
       - name: asdf plugin test
         uses: asdf-vm/actions/plugin-test@4f8f7939dd917fc656bb7c3575969a5988c28364 # v3.0.0
@@ -81,7 +81,7 @@ jobs:
           version: 1.29.0
   secrets:
     name: Secrets
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   tooling:
     name: Update tooling
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write # To push a commit
       pull-requests: write # To open a Pull Request

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   github:
     name: GitHub Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write # To create a GitHub Release
     steps:


### PR DESCRIPTION
## Summary

Upgrade the Ubuntu-based runner used in CI from 22.04 to 24.04. ~~**NOTE:** As of writing this runner is still in beta, so this should not be merged.~~