### PR TITLE
Create explicit uninstall script

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -53,6 +53,7 @@ jobs:
           - download
           - install
           - list-all
+          - uninstall
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,16 @@ test-installation: ## Test the installation
 test-list-all: ## Test run the list-all script
 	@./$(BIN_DIR)/list-all
 
+test-uninstall: | $(TMP_DIR) ## Test run the uninstall script
+ifeq "$(version)" ""
+	@echo 'usage: "make test-uninstall version=1.29.0"'
+else
+	@( \
+		ASDF_INSTALL_PATH="${TMP_DIR}/install/yamllint-$(version)" \
+		./$(BIN_DIR)/uninstall \
+	)
+endif
+
 .PHONY: verify
 verify: format-check lint ## Verify project is in a good state
 

--- a/bin/uninstall
+++ b/bin/uninstall
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+
+set -eo pipefail
+
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "${current_script_path}")")
+# shellcheck source=./lib/common.sh
+source "${plugin_dir}/lib/common.sh"
+
+check_env_var "ASDF_INSTALL_PATH" "${ASDF_INSTALL_PATH}"
+
+rm -rf "${ASDF_INSTALL_PATH}"


### PR DESCRIPTION
Closes #5

## Summary

Create the optional `bin/uninstall` script based on the [docs](https://asdf-vm.com/plugins/create.html#bin-uninstall), the asdf-erlang uninstall script ([ref](https://github.com/asdf-vm/asdf-erlang/blob/826ad0e11d896caf1ffb59405949c2617cf60bbb/bin/uninstall)), and manual debugging. In essence, the script just removes the directory where the version is installed, because of the use of venv everything related to yamllint is present in that directory.