### PR TITLE
Force `pip` to not display an update notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to _asdf-yamllint_ will be documented in this file.
 
 ## Changes
 
+- (2024-11-14) Disable the `pip` update notice.
 - (2024-05-31) Fix invalid option error from `sha256sum`.
 - (2024-05-08) Fix exit code always being 0.
 - (2024-04-04) Use Python venv to install and run `yamllint`.

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -125,6 +125,7 @@ install_version() {
 		${python_command} \
 			-m pip install \
 			--quiet \
+			--disable-pip-version-check \
 			--requirement yamllint.egg-info/requires.txt
 	)
 


### PR DESCRIPTION
## Summary

Update the way `pip` is called to disable it from checking for a version update and thus not output an update notice. This should improve the user experience as the notice is not relevant during the usage of this plugin.