### PR TITLE
Remove secrets check from CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -79,18 +79,3 @@ jobs:
         with:
           command: yamllint --help
           version: 1.29.0
-  secrets:
-    name: Secrets
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-        with:
-          fetch-depth: 0
-      - name: Scan for secrets
-        uses: gitleaks/gitleaks-action@83373cf2f8c4db6e24b41c1a9b086bb9619e9cd3 # v2.3.7
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_ENABLE_COMMENTS: false
-          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
-          GITLEAKS_ENABLE_SUMMARY: false


### PR DESCRIPTION
Relates to 1e2e534221635f5ecac8d762306cccd2e6eecd5a, #4, #139

## Summary

Update the CI to omit the job that checks for secrets and instead rely solely on GitHub for secret scanning in a continuous fashion. Individual contributors can still continue to use any secret scanning software they like locally.

The motivation for this removal is to reduce the supply chain surface by omitting unnecessary dependencies. This dependencies adds limited value (given what GitHub already does for us), requires access to secrets, and has a history of unreliability.