### PR TITLE
Create explicit `latest-stable` script

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -58,6 +58,7 @@ jobs:
         command:
           - download
           - install
+          - latest-stable
           - list-all
     steps:
       - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to _asdf-yamllint_ will be documented in this file.
 
 ## Changes
 
+- (2024-12-03) Implemented dedicated `latest-stable` command.
 - (2024-11-14) Disable the `pip` update notice.
 - (2024-05-31) Fix invalid option error from `sha256sum`.
 - (2024-05-08) Fix exit code always being 0.

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,8 @@ else
 	@git push origin "v$v"
 endif
 
-.PHONY: test-download test-help test-install test-installation test-list-all
-test-download: | $(TMP_DIR) ## Test run the download script
+.PHONY: test-download test-help test-install test-installation test-latest-stable test-list-all
+test-download: | $(TMP_DIR) ## Test the download script
 ifeq "$(version)" ""
 	@echo 'usage: "make test-download version=1.29.0"'
 else
@@ -100,7 +100,7 @@ test-help: ## Test the help scripts
 	@echo "LINKS"
 	@./$(BIN_DIR)/help.links
 
-test-install: | $(TMP_DIR) ## Test run the install script
+test-install: | $(TMP_DIR) ## Test the install script
 ifeq "$(version)" ""
 	@echo 'usage: "make test-install version=1.29.0"'
 else
@@ -125,7 +125,10 @@ test-installation: ## Test the installation
 	@echo '----------'
 	@$(TMP_DIR)/install/bin/yamllint --help
 
-test-list-all: ## Test run the list-all script
+test-latest-stable: ## Test the latest-stable scripts
+	@./$(BIN_DIR)/latest-stable
+
+test-list-all: ## Test the list-all script
 	@./$(BIN_DIR)/list-all
 
 .PHONY: verify

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+
+set -eo pipefail
+
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "${current_script_path}")")
+# shellcheck source=./lib/common.sh
+source "${plugin_dir}/lib/common.sh"
+
+latest_version

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -60,6 +60,11 @@ check_env_var() {
 	fi
 }
 
+latest_version() {
+	curl --silent "${base_url}/json" |
+		jq --raw-output '.info.version'
+}
+
 list_versions() {
 	curl --silent "${base_url}/json" |
 		jq --raw-output '.releases | keys[]' |


### PR DESCRIPTION
Closes #59

## Summary

Create the optional [`bin/latest-stable`](https://asdf-vm.com/plugins/create.html#bin-latest-stable) script based on the docs description of what it should do. It will use the PyPI API to determine the latest stable version.