### PR TITLE
Improve license holders

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 asdf-yamllint Contributors
+Copyright (c) 2024 Eric Cornelissen, Erik Jutemar
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Relates to #120

## Summary

Be explicit about who the license holders are since "asdf-yamllint Contributors" isn't a meaningful term to refer to. Using individual names is more explicit and "safer". The names are based on the displayed name for each contributor on GitHub at the time of this commit.