### PR TITLE
Bump `runs-on:` values

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -96,7 +96,7 @@ jobs:
       matrix:
         include:
           - name: MacOS
-            os: macos-14
+            os: macos-15
           - name: Ubuntu
             os: ubuntu-24.04
     steps:


### PR DESCRIPTION
Relates to #102

## Summary

Following <https://github.blog/changelog/2025-04-10-github-actions-macos-15-and-windows-2025-images-are-now-generally-available/>.