### PR TITLE
Specify `gitref` explicitly for asdf plugin testing

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -124,3 +124,4 @@ jobs:
         with:
           command: yamllint --help
           version: 1.29.0
+          gitref: ${{ github.head_ref || github.ref }}


### PR DESCRIPTION
Relates to #178, #179

## Summary

This is to avoid errors on PRs where the merge commit is transient.