### PR TITLE
Add tool `dockle`

### DIFF
--- a/.dockleignore
+++ b/.dockleignore
@@ -1,0 +1,16 @@
+# Configuration file for Dockle (https://github.com/goodwithtech/dockle)
+
+## root is fine in a dev image
+CIS-DI-0001
+
+## trust is unnecessary for local image
+CIS-DI-0005
+
+## dev image does not need a HEALTHCHECK
+CIS-DI-0006
+
+## latest is fine for a local image
+DKL-DI-0006
+
+## too many false positives
+DKL-LI-0003

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,6 +50,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-24.04
+    needs:
+      - dev-env
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,6 @@
 # Configuration file for asdf (https://asdf-vm.com/)
 actionlint 1.7.7
+dockle 0.4.15
 hadolint 2.14.0
 shellcheck 0.11.0
 shfmt 3.12.0

--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -21,6 +21,7 @@ COPY .tool-versions .
 RUN go install github.com/asdf-vm/asdf/cmd/asdf@v0.16.2 \
 	&& echo 'export PATH="/.asdf/shims:$''PATH"' > ~/.bashrc \
 	&& asdf plugin add actionlint \
+	&& asdf plugin add dockle \
 	&& asdf plugin add hadolint \
 	&& asdf plugin add shellcheck \
 	&& asdf plugin add shfmt \

--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -2,6 +2,8 @@
 
 FROM docker.io/golang:1.24.0-alpine3.21
 
+ENV ASDF_YAMLLINT_CONTAINER=1
+
 RUN apk add --no-cache \
 	# asdf prerequisites
 	bash curl git \

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,9 @@ lint-ci: $(ASDF) ## Lint CI workflow files
 	@SHELLCHECK_OPTS=$(SHELLCHECK_OPTS) \
 		actionlint
 
-lint-container: $(ASDF) ## Lint the Containerfile
+lint-container: $(ASDF) dev-img ## Lint the Containerfile
 	@hadolint Containerfile.dev
+	@[ -z "$$ASDF_YAMLLINT_CONTAINER" ] && dockle asdf-yamllint-dev-img || :
 
 lint-sh: $(ASDF) ## Lint .sh files
 	@SHELLCHECK_OPTS=$(SHELLCHECK_OPTS) \

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,9 @@ lint-ci: $(ASDF) ## Lint CI workflow files
 
 lint-container: $(ASDF) dev-img ## Lint the Containerfile
 	@hadolint Containerfile.dev
-	@[ -z "$$ASDF_YAMLLINT_CONTAINER" ] && dockle asdf-yamllint-dev-img || :
+	@if [ -z "$$ASDF_YAMLLINT_CONTAINER" ]; then \
+		dockle --exit-code 1 --exit-level info asdf-yamllint-dev-img; \
+	fi
 
 lint-sh: $(ASDF) ## Lint .sh files
 	@SHELLCHECK_OPTS=$(SHELLCHECK_OPTS) \

--- a/Makefile
+++ b/Makefile
@@ -141,8 +141,10 @@ $(ASDF): .tool-versions | $(TMP_DIR)
 	@asdf install || true
 	@touch $(ASDF)
 $(DEV_IMG): .tool-versions Containerfile.dev | $(TMP_DIR)
+ifndef ASDF_YAMLLINT_CONTAINER
 	@$(CONTAINER_ENGINE) build \
 		--tag asdf-yamllint-dev-img \
 		--file Containerfile.dev \
 		.
+endif
 	@touch $(DEV_IMG)


### PR DESCRIPTION
Relates to #22

## Summary

Add [`dockle`](https://github.com/goodwithtech/dockle) as a tool dependency to lint the development container image.